### PR TITLE
fix(lsp): allow lsp containing name copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ without leaving your editor.
 ## 📋 Requirements
 
 - **Neovim** `>= 0.11.2` or newer
-- The official **Copilot LSP** server, enabled with `vim.lsp.enable`
+- The official **Copilot LSP** server, enabled with `vim.lsp.enable`, [copilot.lua](https://github.com/zbirenbaum/copilot.lua) or [copilot.vim](https://github.com/github/copilot.vim)
   **TIP:** can be installed with [mason-lspconfig.nvim](https://github.com/mason-org/mason-lspconfig.nvim)
 - A working `lsp/copilot.lua` configuration.
   **TIP:** Included in [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)
+- **Optional**: Other AI cli tools, such as Claude and Gemini, for integrated ai cli experience in neovim.
 
 ## 📦 Installation
 

--- a/lua/sidekick/config.lua
+++ b/lua/sidekick/config.lua
@@ -126,7 +126,7 @@ function M.setup(opts)
     group = group,
     callback = function(ev)
       local client = vim.lsp.get_client_by_id(ev.data.client_id)
-      if client and client.name and string.find(client.name:lower(), "copilot") then
+      if client and M.is_copilot(client) then
         require("sidekick.status").attach(client)
       end
     end,
@@ -178,26 +178,25 @@ function M.setup(opts)
 
     -- attach to existing copilot clients
     notify_focus()
-    for _, client in ipairs(M.get_copilot_clients()) do
+    for _, client in ipairs(M.get_clients()) do
       require("sidekick.status").attach(client)
     end
   end)
 end
 
----@param filter? table
-function M.get_copilot_clients(filter)
-  local clients = {}
-  for _, client in ipairs(vim.lsp.get_clients(filter)) do
-    if client and client.name and string.find(client.name:lower(), "copilot") then
-      table.insert(clients, client)
-    end
-  end
-  return clients
+---@param client vim.lsp.Client
+function M.is_copilot(client)
+  return client.name and client.name:lower():find("copilot")
+end
+
+---@param filter? vim.lsp.get_clients.Filter
+function M.get_clients(filter)
+  return vim.tbl_filter(M.is_copilot, vim.lsp.get_clients(filter))
 end
 
 ---@param buf? number
 function M.get_client(buf)
-  return M.get_copilot_clients({ bufnr = buf or 0 })[1]
+  return M.get_clients({ bufnr = buf or 0 })[1]
 end
 
 function M.set_hl()

--- a/lua/sidekick/config.lua
+++ b/lua/sidekick/config.lua
@@ -184,12 +184,14 @@ function M.setup(opts)
   end)
 end
 
----@param client vim.lsp.Client
+---@param client vim.lsp.Client|string
 function M.is_copilot(client)
-  return client.name and client.name:lower():find("copilot")
+  local name = type(client) == "table" and client.name or client --[[@as string]]
+  return name and name:lower():find("copilot")
 end
 
 ---@param filter? vim.lsp.get_clients.Filter
+---@return vim.lsp.Client[]
 function M.get_clients(filter)
   return vim.tbl_filter(M.is_copilot, vim.lsp.get_clients(filter))
 end

--- a/lua/sidekick/config.lua
+++ b/lua/sidekick/config.lua
@@ -118,7 +118,7 @@ function M.setup(opts)
     group = group,
     callback = function(ev)
       local client = vim.lsp.get_client_by_id(ev.data.client_id)
-      if client and client.name == "copilot" then
+      if client and client.name and string.find(client.name:lower(), "copilot") then
         require("sidekick.status").attach(client)
       end
     end,
@@ -170,15 +170,26 @@ function M.setup(opts)
 
     -- attach to existing copilot clients
     notify_focus()
-    for _, client in ipairs(vim.lsp.get_clients({ name = "copilot" })) do
+    for _, client in ipairs(M.get_copilot_clients()) do
       require("sidekick.status").attach(client)
     end
   end)
 end
 
+---@param filter? table
+function M.get_copilot_clients(filter)
+  local clients = {}
+  for _, client in ipairs(vim.lsp.get_clients(filter)) do
+    if client and client.name and string.find(client.name:lower(), "copilot") then
+      table.insert(clients, client)
+    end
+  end
+  return clients
+end
+
 ---@param buf? number
 function M.get_client(buf)
-  return vim.lsp.get_clients({ name = "copilot", bufnr = buf or 0 })[1]
+  return M.get_copilot_clients({ bufnr = buf or 0 })[1]
 end
 
 function M.set_hl()

--- a/lua/sidekick/health.lua
+++ b/lua/sidekick/health.lua
@@ -19,7 +19,7 @@ function M.check()
 
   start("Sidekick Copilot LSP")
 
-  local clients = Config.get_copilot_clients()
+  local clients = Config.get_clients()
   if #clients > 0 then
     ok("Found active Copilot LSP client(s)")
   else

--- a/lua/sidekick/health.lua
+++ b/lua/sidekick/health.lua
@@ -19,13 +19,14 @@ function M.check()
 
   start("Sidekick Copilot LSP")
 
-  if vim.lsp.is_enabled("copilot") then
-    ok("Copilot LSP is enabled")
+  local clients = Config.get_copilot_clients()
+  if #clients > 0 then
+    ok("Found active Copilot LSP client(s)")
   else
-    error("Copilot LSP is not enabled")
+    error("No active Copilot LSP client found")
   end
 
-  for _, client in ipairs(vim.lsp.get_clients({ name = "copilot" })) do
+  for _, client in ipairs(clients) do
     if client.handlers["didChangeStatus"] == require("sidekick.status").on_status then
       ok("Sidekick is handling Copilot LSP status notifications for client: " .. client.id)
     else

--- a/lua/sidekick/health.lua
+++ b/lua/sidekick/health.lua
@@ -18,19 +18,22 @@ function M.check()
   end
 
   start("Sidekick Copilot LSP")
-
-  local clients = Config.get_clients()
-  if #clients > 0 then
-    ok("Found active Copilot LSP client(s)")
-  else
-    error("No active Copilot LSP client found")
+  local found = false
+  for name in pairs(vim.lsp.config._configs) do
+    if Config.is_copilot(name) and vim.lsp.is_enabled(name) then
+      ok(("Copilot LSP `%s` is enabled"):format(name))
+      found = true
+    end
+  end
+  if not found then
+    error("No Copilot LSP client is enabled")
   end
 
-  for _, client in ipairs(clients) do
+  for _, client in ipairs(Config.get_clients()) do
     if client.handlers["didChangeStatus"] == require("sidekick.status").on_status then
       ok("Sidekick is handling Copilot LSP status notifications for client: " .. client.id)
     else
-      warn("Sidekick is not handling Copilot LSP status notifications for client: " .. client.id)
+      error("Sidekick is not handling Copilot LSP status notifications for client: " .. client.id)
     end
   end
 


### PR DESCRIPTION
## Description

Currently sidekick only allows native copilot lsp installed usually through mason, npm etc, by searching for the exact lsp name but im pretty sure copilot vim uses the same exact copilot lsp as the official one since it is the official plugin backed by Microsoft, as for copilot lua, it uses the same copilot lsp binary as copilot vim. As a result, whatever works with the copilot lsp should hypothetically work with copilot vim and copilot lua, so we dont have to restrict this plugin to users who only use the native lsp. Me personally I dont like the native inline_completion and found it buggy so im still using copilot vim, this pr should allow the copilot lsp from different copilot plugins to be used for nes as well just allowing different copilot lsp names from the plugins. I have only tested this with copilot vim and it seems to work well. All I did was instead of getting clients with the exact name as copilot, I got lsp clients with name containing copilot, as copilot vim uses GitHub Copilot as the name instead and copilot lua probably uses something similar. Another solution could be to just putting all of the official copilot lsp names in a list and finding if those exist, or allowing users to specify the name of their copilot lsp. Anyways thanks for the new plugin!

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

doenst fix any issues

## Screenshots
here's a video of it working with copilot vim, I have side kick enabled in insert mode hence the nes appears in insert mode as well, not because im using copilot vim
![Screen Recording 2025-09-29 at 7 48 11 PM](https://github.com/user-attachments/assets/0535e3b2-6b6a-43ea-b1ec-2d23c735e93b)

