### PR TITLE
feat(tmux): disable status bar in sidekick window

### DIFF
--- a/lua/sidekick/cli/mux/tmux.lua
+++ b/lua/sidekick/cli/mux/tmux.lua
@@ -20,13 +20,13 @@ function M:cmd()
       conf[#conf + 1] = "source-file " .. f
     end
   end
-  conf[#conf + 1] = "set -g status off"
 
   local conf_file = Config.state("tmux-" .. self.session.id .. ".conf")
   vim.fn.writefile(conf, conf_file)
 
-  local cmd = { "tmux", "-f", conf_file, "new", "-A", "-s", self.session.id }
-  vim.list_extend(cmd, self.tool.cmd)
+  local tool_cmd_str = table.concat(self.tool.cmd, " ")
+  local new_shell_cmd = "tmux set-option status off; " .. tool_cmd_str
+  local cmd = { "tmux", "-f", conf_file, "new", "-A", "-s", self.session.id, new_shell_cmd }
   return { cmd = cmd }
 end
 


### PR DESCRIPTION
- Pass "set -g status off" as a command-line argument instead of writing to a config file.                                         │
- Concatenate the tool command into a single string for execution.

## Description

- Related to https://github.com/folke/sidekick.nvim/issues/36

## Related Issue(s)

- Fixes #36


## Screenshots

<img width="1448" height="1796" alt="image" src="https://github.com/user-attachments/assets/e9218d10-2f6f-4164-b796-7c96c8ec882e" />

