### PR TITLE
fix(tmux): add detach-on-destroy option to tmux sessions

### DIFF
--- a/lua/sidekick/cli/mux/tmux.lua
+++ b/lua/sidekick/cli/mux/tmux.lua
@@ -15,6 +15,7 @@ function M:cmd()
   local cmd = { "tmux", "new", "-A", "-s", self.session.id }
   vim.list_extend(cmd, self.tool.cmd)
   vim.list_extend(cmd, { ";", "set-option", "status", "off" })
+  vim.list_extend(cmd, { ";", "set-option", "detach-on-destroy", "on" })
   return { cmd = cmd }
 end
 


### PR DESCRIPTION
Ensure tmux clients automatically detach when a session is destroyed, preventing recursive tmux-in-tmux session loops and ensuring the expected behavior.

## Description

If the user has the tmux option: 
`set -g detach-on-destroy off`
When closing the tmux session from the CLI app it is going to enter in an infinite loop of tmux inside tmux.

## Screenshots

<img width="1897" height="888" alt="image" src="https://github.com/user-attachments/assets/90d3159b-3796-4dba-b51b-5664f63cc81e" />


