### PR TITLE
fix(cli): prevent false positive detection of amazon_q tool

### DIFF
--- a/sk/cli/amazon_q.lua
+++ b/sk/cli/amazon_q.lua
@@ -1,6 +1,6 @@
 ---@type sidekick.cli.Config
 return {
   cmd = { "q" },
-  is_proc = "\\<q\\>",
+  is_proc = "^q$",
   url = "https://github.com/aws/amazon-q-developer-cli"
 }


### PR DESCRIPTION
## Description

When calling `.select({ filter = { installed = true } })` the amazon_q tool appears in the selection list even though the `q` command is not actually installed on the system. 
This occurs despite the `installed = true` filter being applied, which should only show tools that are genuinely installed.

## Root Cause

The issue stems from how sidekick.nvim detects running processes to determine if a tool is "installed":

The amazon_q tool configuration uses `is_proc  = "\\<q\\>"` to detect running processes.
This regex pattern matches word-bounded `q` characters.

When used with `fzf-lua` plugin (I'm using LazyVim 👍) generates fzf commands with placeholder patterns like `{q}`, `{+}`, and `{n}` for dynamic query substitution. 
The `q` character inside `{q}` is treated as  word-bounded and matches the `\\<q\\>` regex pattern.

Since sidekick detects the fzf process as an "amazon_q" process, it creates a session state with `installed = true`, causing the tool to pass through the `{ installed = true }` filter.

## Proposed Solution

Use more specific regex pattern:
Current: `is_proc = "\\<q\\>"`
Proposed: `is_proc = "^b$"`

## Testing

The fix can be verified by:
1. Ensuring vim.fn.executable('q') returns `0` (not installed)
2. Running fzf-lua commands that generate `{q}` placeholders
3. Calling `require("sidekick.cli").select({ filter = { installed = true } })`
4. Confirming amazon_q no longer appears in the filtered list

## Related Issue(s)
n/a

## Screenshots
*`claudecode` `codex-cli` is installed on my machine.
<img width="908" height="835" alt="CleanShot 2025-10-08 at 23 16 34" src="https://github.com/user-attachments/assets/9936772b-8517-47b7-96dc-367a2ed1a3bf" />
<img width="908" height="779" alt="CleanShot 2025-10-08 at 23 17 00" src="https://github.com/user-attachments/assets/a55d135f-bdcf-4ed4-9463-b24adbf19127" />


Note: I'm relatively new to Lua, so please let me know if there's a more idiomatic way to handle this or if I've missed any edge cases.