### PR TITLE
fix(terminal): prevent nvim crash on `i` in scrollback

### DIFF
--- a/lua/sidekick/cli/terminal.lua
+++ b/lua/sidekick/cli/terminal.lua
@@ -479,16 +479,17 @@ function M:scrollback()
   vim.bo[buf].bufhidden = "wipe"
   vim.api.nvim_win_set_buf(self.win, buf)
   local term = vim.api.nvim_open_term(buf, {})
-  vim.api.nvim_create_autocmd({ "TermEnter" }, {
-    buffer = buf,
-    callback = function()
-      vim.api.nvim_win_set_buf(self.win, self.buf)
-      self:wo()
-      if vim.api.nvim_buf_is_valid(buf) then
-        pcall(vim.api.nvim_buf_delete, buf, { force = true })
-      end
-    end,
-  })
+  local function exit_scrollback()
+    vim.api.nvim_win_set_buf(self.win, self.buf)
+    self:wo()
+    if vim.api.nvim_buf_is_valid(buf) then
+      pcall(vim.api.nvim_buf_delete, buf, { force = true })
+    end
+  end
+  for _, key in ipairs({ "i", "a", "I", "A" }) do
+    vim.keymap.set("n", key, exit_scrollback, { silent = true, buffer = buf })
+  end
+  vim.api.nvim_create_autocmd({ "TermEnter" }, { buffer = buf, callback = exit_scrollback })
   vim.api.nvim_create_autocmd({ "TextChangedT", "TextChanged" }, {
     buffer = buf,
     callback = function()


### PR DESCRIPTION
## Description

Fixes nvim (both stable and nightly) exiting on `i` in scrollback with tmux.
`:noautocmd startinsert` in scrollback also crashes nvim.
Not sure why `TermEnter` doesn't work. 

Versions:
```
nvim -v
NVIM v0.12.0-dev-1379+ga4006360f1
Build type: RelWithDebInfo
LuaJIT 2.1.1753364724
Run "nvim -V1 -v" for more info

tmux -V
tmux 3.5a

kitty --version
kitty 0.43.1 created by Kovid Goyal

macOS Sequola 15.5
```

## Related Issue(s)

None

## Screenshots

None

