### PR TITLE
fix(terminal): allow auto split width/height

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,8 +289,8 @@ local defaults = {
       -- Options used when layout is "left"|"bottom"|"top"|"right"
       ---@type vim.api.keyset.win_config
       split = {
-        width = 80,
-        height = 20,
+        width = 80, -- set to 0 for default split with
+        height = 20, -- set to 0 for default split height
       },
       --- CLI Tool Keymaps (default mode is `t`)
       ---@type table<string, sidekick.cli.Keymap|false>

--- a/lua/sidekick/cli/terminal.lua
+++ b/lua/sidekick/cli/terminal.lua
@@ -285,21 +285,16 @@ function M:open_win()
     vim.deepcopy(is_float and self.opts.float or self.opts.split)
   )
 
-  if opts.width == 0 then
-    opts.width = nil
-  else
-    opts.width = opts.width <= 1 and math.floor(vim.o.columns * opts.width) or opts.width
-  end
-  if opts.height == 0 then
-    opts.height = nil
-  else
-    opts.height = opts.height <= 1 and math.floor(vim.o.lines * opts.height) or opts.height
-  end
+  opts.width = opts.width <= 1 and math.floor(vim.o.columns * opts.width) or opts.width
+  opts.height = opts.height <= 1 and math.floor(vim.o.lines * opts.height) or opts.height
 
   if is_float then
-    opts.row = opts.row <= 1 and math.floor((vim.o.lines - (opts.height or 0)) * opts.row) or opts.row
-    opts.col = opts.col <= 1 and math.floor((vim.o.columns - (opts.width or 0)) * opts.col) or opts.col
+    opts.width, opts.height = math.max(opts.width, 80), math.max(opts.height, 10) -- minimum size
+    opts.row = opts.row <= 1 and math.floor((vim.o.lines - opts.height) * opts.row) or opts.row
+    opts.col = opts.col <= 1 and math.floor((vim.o.columns - opts.width) * opts.col) or opts.col
   else
+    opts.width = opts.width > 0 and opts.width or nil -- auto split width
+    opts.height = opts.height > 0 and opts.height or nil -- auto split height
     opts.vertical = self.opts.layout == "top" or self.opts.layout == "bottom"
     opts.split = ({ top = "above", left = "left", bottom = "below", right = "right" })[self.opts.layout] or "right"
   end

--- a/lua/sidekick/config.lua
+++ b/lua/sidekick/config.lua
@@ -54,8 +54,8 @@ local defaults = {
       -- Options used when layout is "left"|"bottom"|"top"|"right"
       ---@type vim.api.keyset.win_config
       split = {
-        width = 80,
-        height = 20,
+        width = 80, -- set to 0 for default split with
+        height = 20, -- set to 0 for default split height
       },
       --- CLI Tool Keymaps (default mode is `t`)
       ---@type table<string, sidekick.cli.Keymap|false>


### PR DESCRIPTION
Fixes the error on `nvim_open_win` when `cli.win.split.width = 0` or `cli.win.split.height = 0`.

```
vim.schedule callback: ...re/nvim/lazy/sidekick.nvim/lua/sidekick/cli/terminal.lua:307: 'width' key must be a positive Integer
```

In this case, the size is now set automatically by vim (as for any buffer).