### PR TITLE
fix(terminal): safer way of entering terminal mode from scrollback buffer

### DIFF
--- a/lua/sidekick/cli/scrollback.lua
+++ b/lua/sidekick/cli/scrollback.lua
@@ -128,7 +128,11 @@ function M:update(opts)
   local mode = opts.mode or vim.fn.mode()
   local is_open = self:is_open()
   if mode == "t" and (self:is_focused() or self:in_terminal()) and is_open then
-    self:close()
+    vim.cmd.stopinsert()
+    vim.schedule(function()
+      self:close()
+      vim.cmd.startinsert()
+    end)
   elseif mode ~= "t" and not is_open then
     self:open(opts.win_pos)
   end


### PR DESCRIPTION
## Description

After latest commits, the #103 issue is coming back. Nvim exit when I press `i` in scrollback with tmux.

## Related Issue(s)

#103 

## Screenshots

Exactly the same as #103 's gif.

