### PR TITLE
fix(cli): improve location formatting and message starting (#59)

### DIFF
--- a/lua/sidekick/cli/context/location.lua
+++ b/lua/sidekick/cli/context/location.lua
@@ -45,6 +45,7 @@ function M.get(ctx, opts)
     end
   end
 
+  add(" ")
   add("@")
   ret[#ret + 1] = { name, "SidekickLocFile" }
 
@@ -64,6 +65,7 @@ function M.get(ctx, opts)
       add(":", "L", from[1], ":", "C", from[2] + 1)
     end
   end
+  add(" ")
 
   return { ret }
 end

--- a/lua/sidekick/cli/init.lua
+++ b/lua/sidekick/cli/init.lua
@@ -191,7 +191,7 @@ function M.send(opts)
     Util.exit_visual_mode()
     vim.schedule(function()
       msg = state.tool:format(text)
-      state.session:send(msg .. "\n")
+      state.session:send(msg)
       if opts.submit then
         state.session:submit()
       end


### PR DESCRIPTION
## Description

This PR introduces two quality-of-life improvements for sending messages to the CLI. While these changes are partly a matter of preference, here are the key reasons behind them:

* Most chat and AI-CLI interfaces display file references inline.
* The AI CLI documentation demonstrates inline usage.
* Adding a space before the `@` ensures a clear separation between the message and the file reference, guaranteeing that the read action is properly triggered (e.g., `[first part of the message ...] @path`).
* Including a space after the filename when sending a file or buffer ensures the filename is clearly separated from the rest of the message, preventing it from being mixed with the text content.

## Related Issue(s)

#59