### PR TITLE
fix(nes.edit): add buffer validation before accessing position

### DIFF
--- a/lua/sidekick/nes/edit.lua
+++ b/lua/sidekick/nes/edit.lua
@@ -33,8 +33,10 @@ function M.new(client, edit)
   local fname = vim.uri_to_fname(edit.textDocument.uri)
   self.buf = vim.fn.bufnr(fname, false)
 
-  self.from, self.to = pos(client, self.buf, self.range.start), pos(client, self.buf, self.range["end"])
-  self.to = Util.fix_pos(self.buf, self.to)
+  if self.buf ~= -1 and vim.api.nvim_buf_is_valid(self.buf) then
+    self.from, self.to = pos(client, self.buf, self.range.start), pos(client, self.buf, self.range["end"])
+    self.to = Util.fix_pos(self.buf, self.to)
+  end
   return self
 end
 


### PR DESCRIPTION
## Description

Adds a buffer validity check before accessing buffer positions in `nes/edit.lua` to prevent errors when the buffer is invalid (-1).

