### PR TITLE
docs(readme): update snacks picker integration to use new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,7 +648,7 @@ If you're using [snacks.nvim](https://github.com/folke/snacks.nvim), you can sen
     picker = {
       actions = {
         sidekick_send = function(...)
-          return require("sidekick.cli.snacks").send(...)
+          return require("sidekick.cli.picker.snacks").send(...)
         end,
       },
       win = {


### PR DESCRIPTION
Thanks for this great plugin and all the rest 🙇 

---

## Description

`sidekick.cli.snacks` has been deprecated in favor of `sidekick.cli.picker.snacks`.

This PR updates the snippet in the README.

https://github.com/folke/sidekick.nvim/blob/dc2710af65a542eb3010136d7664b626633f0229/lua/sidekick/cli/snacks.lua#L8

## Screenshots

Warning

<img width="507" height="59" alt="image" src="https://github.com/user-attachments/assets/c2bdca77-dd6a-48d2-ae27-6a8dfb2bdf23" />


