### PR TITLE
fix(codex): update deprecated search option

### DIFF
--- a/sk/cli/codex.lua
+++ b/sk/cli/codex.lua
@@ -1,6 +1,6 @@
 ---@type sidekick.cli.Config
 return {
-  cmd = { "codex", "--search" },
+  cmd = { "codex", "--enable", "web_search_request" },
   is_proc = "\\<codex\\>",
   url = "https://github.com/openai/codex",
   resume = { "resume" },


### PR DESCRIPTION
## Description

Latest codex version v0.53.0  has deprecated `--search` for `--enable web_search_request`
