### PR TITLE
feat(session): filter external sessions based on mux config

### DIFF
--- a/lua/sidekick/cli/session/init.lua
+++ b/lua/sidekick/cli/session/init.lua
@@ -138,11 +138,15 @@ function M.sessions()
     for _, s in pairs(backend:sessions()) do
       s.backend = name
       s.started = true
-      ret[#ret + 1] = M.new(s)
-      assert(not ids[s.id], "duplicate session id: " .. s.id)
-      ids[s.id] = true
-      if M._attached[s.id] then
-        M._attached[s.id] = ret[#ret] -- update to latest session instance
+      local session = M.new(s)
+      -- Filter out external sessions when mux is disabled
+      if not session.external or Config.cli.mux.enabled then
+        ret[#ret + 1] = session
+        assert(not ids[session.id], "duplicate session id: " .. session.id)
+        ids[session.id] = true
+        if M._attached[session.id] then
+          M._attached[session.id] = ret[#ret] -- update to latest session instance
+        end
       end
     end
   end

--- a/tests/session_filter_spec.lua
+++ b/tests/session_filter_spec.lua
@@ -1,0 +1,98 @@
+local Session = require("sidekick.cli.session")
+local Config = require("sidekick.config")
+
+describe("session external filtering", function()
+  local original_backends
+  local original_did_setup
+
+  before_each(function()
+    -- Save original state
+    original_backends = Session.backends
+    original_did_setup = Session.did_setup
+
+    -- Reset session state and prevent auto-setup
+    Session._attached = {}
+    Session.backends = {}
+    Session.did_setup = true -- prevent setup() from auto-registering backends
+  end)
+
+  after_each(function()
+    -- Restore original state
+    Session._attached = {}
+    Session.backends = original_backends
+    Session.did_setup = original_did_setup
+  end)
+
+  describe("Session.sessions()", function()
+    it("includes external sessions when mux.enabled = true", function()
+      Config.cli.mux.enabled = true
+
+      -- Register a mock backend that returns an external session
+      Session.backends.mock_backend = {
+        sessions = function()
+          return { { id = "ext1", tool = "test", cwd = "/tmp" } }
+        end,
+        init = function(self)
+          self.external = true -- mark session as external
+        end,
+      }
+
+      local sessions = Session.sessions()
+      assert.are.equal(1, #sessions)
+      assert.are.equal("ext1", sessions[1].id)
+    end)
+
+    it("filters external sessions when mux.enabled = false", function()
+      Config.cli.mux.enabled = false
+
+      -- Register a mock backend that returns an external session
+      Session.backends.mock_backend = {
+        sessions = function()
+          return { { id = "ext1", tool = "test", cwd = "/tmp" } }
+        end,
+        init = function(self)
+          self.external = true -- mark session as external
+        end,
+      }
+
+      local sessions = Session.sessions()
+      assert.are.equal(0, #sessions)
+    end)
+
+    it("includes non-external sessions regardless of mux.enabled", function()
+      Config.cli.mux.enabled = false
+
+      -- Register a mock backend that returns a non-external session
+      Session.backends.mock_backend = {
+        sessions = function()
+          return { { id = "local1", tool = "test", cwd = "/tmp" } }
+        end,
+        init = function(self)
+          self.external = false -- mark session as non-external
+        end,
+      }
+
+      local sessions = Session.sessions()
+      assert.are.equal(1, #sessions)
+      assert.are.equal("local1", sessions[1].id)
+    end)
+
+    it("includes sessions with nil external flag regardless of mux.enabled", function()
+      Config.cli.mux.enabled = false
+
+      -- Register a mock backend that returns a session without external flag
+      Session.backends.mock_backend = {
+        sessions = function()
+          return { { id = "local1", tool = "test", cwd = "/tmp" } }
+        end,
+        init = function(self)
+          -- don't set external, it defaults to nil
+        end,
+      }
+
+      local sessions = Session.sessions()
+      assert.are.equal(1, #sessions)
+      assert.are.equal("local1", sessions[1].id)
+    end)
+  end)
+end)


### PR DESCRIPTION

## Description

- Add logic to `Session.sessions()` to filter out external sessions when `Config.cli.mux.enabled` is false.
- External sessions are now only included if multiplexing is enabled.
- Non-external sessions are always included.
- Add new test suite `tests/session_filter_spec.lua` to verify filtering behavior.

## Related Issue(s)

 - Fixes #168 


## Screenshots

<!-- Add screenshots of the changes if applicable. -->

