### PR TITLE
fix(cli): enable file watch for external sessions to ensure buffer re…

### DIFF
--- a/lua/sidekick/cli/session/init.lua
+++ b/lua/sidekick/cli/session/init.lua
@@ -191,6 +191,12 @@ function M.attach(session)
     session:start()
   end
   M._attached[session.id] = session
+
+  -- Enable watch for any attached session (not just terminal)
+  if Config.cli.watch then
+    require("sidekick.cli.watch").enable()
+  end
+
   Util.emit("SidekickCliAttach", { id = session.id })
   return session
 end


### PR DESCRIPTION
…load

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Fixes buffer auto-reload when using CLI tools (OpenCode, Aider, etc.) in window/split modes with external multiplexer sessions (tmux/zellij)
Previously, file watching was only enabled for terminal sessions, causing buffers to remain stale after external edits.

Fix: Moved watch enablement to session/init.lua:attach() so it applies to all session types regardless of backend.


