### PR TITLE
fix: Codex crashing on start

### DIFF
--- a/lua/sidekick/config.lua
+++ b/lua/sidekick/config.lua
@@ -103,7 +103,7 @@ local defaults = {
       aider = { cmd = { "aider" } },
       amazon_q = { cmd = { "q" } },
       claude = { cmd = { "claude" } },
-      codex = { cmd = { "codex", "--enable", "web_search_request" } },
+      codex = { cmd = { "codex", "--search" } },
       copilot = { cmd = { "copilot", "--banner" } },
       crush = {
         cmd = { "crush" },

--- a/sk/cli/codex.lua
+++ b/sk/cli/codex.lua
@@ -1,6 +1,6 @@
 ---@type sidekick.cli.Config
 return {
-  cmd = { "codex", "--enable", "web_search_request" },
+  cmd = { "codex", "--search" },
   is_proc = "\\<codex\\>",
   url = "https://github.com/openai/codex",
   resume = { "resume" },


### PR DESCRIPTION
"codex --enable web_search_request" seems deprecated. "codex --search" enables web search

## Description

Start codex with `codex --search` to avoid codex crashing

## Related Issue(s)
  - Fixes #181 

## Screenshots
Before:
<img width="742" height="280" alt="image" src="https://github.com/user-attachments/assets/1933e1ba-8f2f-4803-a0ff-b9f03f893bd2" />

After: 
<img width="758" height="631" alt="image" src="https://github.com/user-attachments/assets/ce0c7476-c706-4cfe-a61e-2fd86bd11c61" />


