### PR TITLE
fix(cli): improve claude code line ranges transformation. Closes #159

### DIFF
--- a/sk/cli/claude.lua
+++ b/sk/cli/claude.lua
@@ -15,7 +15,11 @@ return {
     local ret = Text.to_string(text)
 
     -- transform line ranges to a format that Claude understands
+    ret = ret:gsub("@([^@]-) :L(%d+):C%d+%-L(%d+):C%d+", "@%1#L%2-%3")
+    ret = ret:gsub("@([^@]-) :L(%d+):C%d+%-C%d+", "@%1#L%2")
     ret = ret:gsub("@([^@]-) :L(%d+)%-L(%d+)", "@%1#L%2-%3")
+    ret = ret:gsub("@([^@]-) :L(%d+):C%d+", "@%1#L%2")
+    ret = ret:gsub("@([^@]-) :L(%d+)", "@%1#L%2")
 
     return ret
   end,


### PR DESCRIPTION
## Description

Improve Claude Code range transformation. The current transformation only supports lines ranges where the initial and final lines are different.

The implemented fix handles the cases where:
- a single line is sent (line at cursor, visual selection within a line, visual line selection)
- multi-line is sent (multi-line visual selection, multi-line visual line selection)

## Related Issue(s)

Fixes #159

## Additional Context

It should be merged after #184 has been fixed so we can check that also multi-line visual selection with cols works as expected