### PR TITLE
fix(cli): apply focus option for external tmux sessions

### DIFF
--- a/lua/sidekick/cli/session/init.lua
+++ b/lua/sidekick/cli/session/init.lua
@@ -52,6 +52,9 @@ function B:attach() end
 --- Detach from an existing session
 function B:detach() end
 
+--- Focus an external session (tmux/zellij pane)
+function B:focus() end
+
 --- Start a new session
 --- If the backend returns a Cmd, a new terminal session will be spawned
 ---@return sidekick.cli.terminal.Cmd?

--- a/lua/sidekick/cli/session/tmux.lua
+++ b/lua/sidekick/cli/session/tmux.lua
@@ -195,4 +195,13 @@ function M:dump()
   return ret
 end
 
+---Focus the tmux pane
+function M:focus()
+  local pane_id = self:pane_id()
+  if not pane_id then
+    return
+  end
+  Util.exec({ "tmux", "select-pane", "-t", pane_id })
+end
+
 return M

--- a/lua/sidekick/cli/session/tmux.lua
+++ b/lua/sidekick/cli/session/tmux.lua
@@ -199,9 +199,10 @@ end
 function M:focus()
   local pane_id = self:pane_id()
   if not pane_id then
-    return
+    return self
   end
   Util.exec({ "tmux", "select-pane", "-t", pane_id })
+  return self
 end
 
 return M

--- a/lua/sidekick/cli/state.lua
+++ b/lua/sidekick/cli/state.lua
@@ -194,8 +194,14 @@ function M.attach(state, opts)
         terminal:focus()
       end
     end
-  elseif attached then
-    Util.info("Attached to `" .. state.tool.name .. "`")
+  else
+    -- External session (tmux/zellij pane)
+    if opts.focus and state.external and session.focus then
+      session:focus()
+    end
+    if attached then
+      Util.info("Attached to `" .. state.tool.name .. "`")
+    end
   end
   return state, attached
 end


### PR DESCRIPTION
## Description

Fixes #179

When using tmux with `create = "split"` or `create = "window"`, the `focus` option was not being applied because external tmux sessions don't have a Neovim terminal window. The existing focus logic only worked for terminal-based sessions.

### Manual Testing

With the following configuration:

```lua
cli = {
  mux = {
    backend = "tmux",
    enabled = true,
    create = "split",
  },
}
```

Running `require("sidekick.cli").toggle({ name = "opencode", focus = true })` or `require("sidekick.cli").focus()` now correctly focuses the tmux pane.