### PR TITLE
feat(terminal): balance window sizes after opening non-float terminal

### DIFF
--- a/lua/sidekick/cli/terminal.lua
+++ b/lua/sidekick/cli/terminal.lua
@@ -375,6 +375,11 @@ function M:open_win()
   vim.w[self.win].sidekick_cli = self.tool
   vim.w[self.win].sidekick_session_id = self.id
   self:wo()
+
+  -- Balance window sizes after opening
+  if not is_float then
+    vim.cmd("wincmd =")
+  end
 end
 
 function M:focus()


### PR DESCRIPTION


## Description

Automatically balance window sizes using `wincmd =` when opening a terminal in split mode (not floating). This improves the user experience by ensuring consistent window sizing when the terminal is opened as a split pane.

## Screenshots

Before add this patch, it behaves like this:

![wo](https://github.com/user-attachments/assets/f4418e8e-1ab1-48ab-b2a5-4c9b74acb0dd)

After add this patch, the width of all windows (except the window of sidekick) will keep equal: 

![with](https://github.com/user-attachments/assets/b996a4cc-c34f-43c3-a223-5cec12361130)
