### PR TITLE
fix(cli): replace amazon_q with kiro

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,6 @@ local defaults = {
     ---@type table<string, sidekick.cli.Config|{}>
     tools = {
       aider = { cmd = { "aider" } },
-      amazon_q = { cmd = { "q" } },
       claude = { cmd = { "claude" } },
       codex = { cmd = { "codex", "--enable", "web_search_request" } },
       copilot = { cmd = { "copilot", "--banner" } },
@@ -347,6 +346,7 @@ local defaults = {
       cursor = { cmd = { "cursor-agent" } },
       gemini = { cmd = { "gemini" } },
       grok = { cmd = { "grok" } },
+      kiro = { cmd = { "kiro-cli" } },
       opencode = {
         cmd = { "opencode" },
         -- HACK: https://github.com/sst/opencode/issues/445
@@ -721,19 +721,19 @@ The default keymaps are:
 
 Sidekick preconfigures popular AI CLIs. Run `:checkhealth sidekick` to see which ones are installed.
 
-| Tool                                                        | Description          | Installation                                                                                                           |
-| ----------------------------------------------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| [`aider`](https://github.com/Aider-AI/aider)                | AI pair programmer   | `pip install aider-chat` or `pipx install aider-chat`                                                                  |
-| [`amazon_q`](https://github.com/aws/amazon-q-developer-cli) | Amazon Q Developer   | [Install guide](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-getting-started-installing.html) |
-| [`claude`](https://github.com/anthropics/claude-code)       | Claude Code CLI      | `npm install -g @anthropic-ai/claude-code`                                                                             |
-| [`codex`](https://github.com/openai/codex)                  | OpenAI Codex CLI     | See [OpenAI docs](https://github.com/openai/codex)                                                                     |
-| [`copilot`](https://github.com/github/copilot-cli)          | GitHub Copilot CLI   | `npm install -g @githubnext/github-copilot-cli`                                                                        |
-| [`crush`](https://github.com/charmbracelet/crush)           | Charm's AI assistant | See [installation](https://github.com/charmbracelet/crush)                                                             |
-| [`cursor`](https://cursor.com/cli)                          | Cursor CLI agent     | See [Cursor docs](https://cursor.com/cli)                                                                              |
-| [`gemini`](https://github.com/google-gemini/gemini-cli)     | Google Gemini CLI    | See [repo](https://github.com/google-gemini/gemini-cli)                                                                |
-| [`grok`](https://github.com/superagent-ai/grok-cli)         | xAI Grok CLI         | See [repo](https://github.com/superagent-ai/grok-cli)                                                                  |
-| [`opencode`](https://github.com/sst/opencode)               | OpenCode CLI         | `npm install -g opencode`                                                                                              |
-| [`qwen`](https://github.com/QwenLM/qwen-code)               | Alibaba Qwen Code    | See [repo](https://github.com/QwenLM/qwen-code)                                                                        |
+| Tool                                                    | Description          | Installation                                               |
+| ------------------------------------------------------- | -------------------- | ---------------------------------------------------------- |
+| [`aider`](https://github.com/Aider-AI/aider)            | AI pair programmer   | `pip install aider-chat` or `pipx install aider-chat`      |
+| [`claude`](https://github.com/anthropics/claude-code)   | Claude Code CLI      | `npm install -g @anthropic-ai/claude-code`                 |
+| [`codex`](https://github.com/openai/codex)              | OpenAI Codex CLI     | See [OpenAI docs](https://github.com/openai/codex)         |
+| [`copilot`](https://github.com/github/copilot-cli)      | GitHub Copilot CLI   | `npm install -g @githubnext/github-copilot-cli`            |
+| [`crush`](https://github.com/charmbracelet/crush)       | Charm's AI assistant | See [installation](https://github.com/charmbracelet/crush) |
+| [`cursor`](https://cursor.com/cli)                      | Cursor CLI agent     | See [Cursor docs](https://cursor.com/cli)                  |
+| [`gemini`](https://github.com/google-gemini/gemini-cli) | Google Gemini CLI    | See [repo](https://github.com/google-gemini/gemini-cli)    |
+| [`grok`](https://github.com/superagent-ai/grok-cli)     | xAI Grok CLI         | See [repo](https://github.com/superagent-ai/grok-cli)      |
+| [`kiro`](https://kiro.dev/cli/)                         | Kiro CLI             | See [Get started](https://kiro.dev/docs/cli/)              |
+| [`opencode`](https://github.com/sst/opencode)           | OpenCode CLI         | `npm install -g opencode`                                  |
+| [`qwen`](https://github.com/QwenLM/qwen-code)           | Alibaba Qwen Code    | See [repo](https://github.com/QwenLM/qwen-code)            |
 
 > [!TIP]
 > After installing tools, restart Neovim or run `:Sidekick cli select` to see them available.

--- a/lua/sidekick/config.lua
+++ b/lua/sidekick/config.lua
@@ -101,7 +101,6 @@ local defaults = {
     ---@type table<string, sidekick.cli.Config|{}>
     tools = {
       aider = { cmd = { "aider" } },
-      amazon_q = { cmd = { "q" } },
       claude = { cmd = { "claude" } },
       codex = { cmd = { "codex", "--enable", "web_search_request" } },
       copilot = { cmd = { "copilot", "--banner" } },
@@ -113,6 +112,7 @@ local defaults = {
       cursor = { cmd = { "cursor-agent" } },
       gemini = { cmd = { "gemini" } },
       grok = { cmd = { "grok" } },
+      kiro = { cmd = { "kiro-cli" } },
       opencode = {
         cmd = { "opencode" },
         -- HACK: https://github.com/sst/opencode/issues/445

--- a/sk/cli/amazon_q.lua
+++ b/sk/cli/amazon_q.lua
@@ -1,6 +1,0 @@
----@type sidekick.cli.Config
-return {
-  cmd = { "q" },
-  is_proc = "\\<qchat\\>",
-  url = "https://github.com/aws/amazon-q-developer-cli",
-}

--- a/sk/cli/kiro.lua
+++ b/sk/cli/kiro.lua
@@ -1,0 +1,6 @@
+---@type sidekick.cli.Config
+return {
+  cmd = { "kiro-cli" },
+  is_proc = "\\<kiro-cli\\>",
+  url = "https://kiro.dev/cli/",
+}


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Amazon Q Developer CLI is no long being actively maintained and will only receive critical security fixes. It is now available as Kiro CLI, a closed-source product.

This change replaces current Amazon Q integration with Kiro CLI.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

- Fixes #210.

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

<img width="2028" height="1267" alt="Kiro CLI selection" src="https://github.com/user-attachments/assets/c55f66aa-00f8-4efe-9c17-9e2eb7ab5d9a" />

<img width="2028" height="1267" alt="Kiro CLI session integration" src="https://github.com/user-attachments/assets/f63330ea-a6fe-4cc0-a28b-7c91312756eb" />

