### PR TITLE
fix(picker): focus terminal correctly when close

### DIFF
--- a/lua/sidekick/cli/actions.lua
+++ b/lua/sidekick/cli/actions.lua
@@ -29,6 +29,9 @@ local function picker(source, t)
       on_show = function()
         t.normal_mode = false
       end,
+      on_close = function()
+        t:focus()
+      end,
     })
   end)
 end


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

When closing the file picker without selecting any, the terminal lost the focus

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots



https://github.com/user-attachments/assets/d06da7a3-fe89-40b4-ad15-5315d35821ec


https://github.com/user-attachments/assets/b2cf25e4-3a60-45af-8091-fe4b7a30c07f



<!-- Add screenshots of the changes if applicable. -->

