### PR TITLE
feat(cli): add cwd option for parent directory context

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,18 @@ current file, selection, diagnostics, and more.
 
 </details>
 
+### Custom Working Directory
+
+You can override the working directory used when resolving context variables
+by passing a `cwd` option to `send()`, `prompt()`, or `render()`:
+
+```lua
+require("sidekick.cli").send({
+  msg = "{file}",
+  cwd = "/path/to/custom/directory"
+})
+```
+
 ### Snacks.nvim Picker Integration
 
 If you're using [snacks.nvim](https://github.com/folke/snacks.nvim), you can send picker selections directly to Sidekick's AI CLI tools. This is useful for sending search results, grep matches, or file selections as context.

--- a/lua/sidekick/cli/context/init.lua
+++ b/lua/sidekick/cli/context/init.lua
@@ -79,9 +79,10 @@ M.context = {
 local C = {}
 C.__index = C
 
-function C.new()
+---@param cwd? string Optional cwd override for path resolution
+function C.new(cwd)
   local self = setmetatable({}, C)
-  self.ctx = M.ctx()
+  self.ctx = M.ctx(cwd)
   self.context = {}
   return self
 end
@@ -190,7 +191,8 @@ function M.fn(name)
   return Config.cli.context[name] or M.context[name] or nil
 end
 
-function M.ctx()
+---@param cwd_override? string Optional cwd override for path resolution
+function M.ctx(cwd_override)
   ---@param w integer
   local wins = vim.tbl_filter(function(w)
     local buf = vim.api.nvim_win_get_buf(w)
@@ -206,7 +208,7 @@ function M.ctx()
   return {
     win = win,
     buf = buf,
-    cwd = vim.fs.normalize(vim.fn.getcwd(win)),
+    cwd = vim.fs.normalize(cwd_override or vim.fn.getcwd(win)),
     row = cursor[1],
     col = cursor[2] + 1,
     range = M.selection(buf),

--- a/lua/sidekick/cli/context/location.lua
+++ b/lua/sidekick/cli/context/location.lua
@@ -23,10 +23,15 @@ function M.get(ctx, opts)
   if not name or name == "" then
     name = "[No Name]"
   else
-    local cwd = ctx.cwd or vim.fn.getcwd(0)
-    local ok, rel = pcall(vim.fs.relpath, cwd, name)
+    local cwd = vim.fs.normalize(ctx.cwd or vim.fn.getcwd(0))
+    local normalized_name = vim.fs.normalize(name)
+    -- Try vim.fs.relpath first
+    local ok, rel = pcall(vim.fs.relpath, normalized_name, cwd)
     if ok and rel and rel ~= "" and rel ~= "." then
       name = rel
+    elseif normalized_name:sub(1, #cwd + 1) == cwd .. "/" then
+      -- Fallback: manual string prefix removal
+      name = normalized_name:sub(#cwd + 2)
     end
   end
 

--- a/lua/sidekick/cli/init.lua
+++ b/lua/sidekick/cli/init.lua
@@ -54,8 +54,12 @@ local function filter_opts(opts)
   return opts
 end
 
+---@class sidekick.cli.PromptOpts
+---@field cb? fun(msg?:string, text?:sidekick.Text[])
+---@field cwd? string Override cwd for context resolution
+
 --- Select a prompt to send
----@param opts? sidekick.cli.Prompt|{cb:nil}
+---@param opts? sidekick.cli.PromptOpts
 ---@overload fun(cb:fun(msg?:string))
 function M.prompt(opts)
   opts = opts or {}

--- a/lua/sidekick/cli/init.lua
+++ b/lua/sidekick/cli/init.lua
@@ -35,6 +35,7 @@ local M = {}
 
 ---@class sidekick.cli.Send: sidekick.cli.Show,sidekick.cli.Message
 ---@field submit? boolean
+---@field cwd? string Override cwd for context resolution (e.g., parent directory)
 
 --- Keymap options similar to `vim.keymap.set` and `lazy.nvim` mappings
 ---@class sidekick.cli.Keymap: vim.keymap.set.Opts
@@ -161,8 +162,9 @@ end
 
 -- Render a message template or prompt
 ---@param opts? sidekick.cli.Message|string
-function M.render(opts)
-  return Context.get():render(opts or "")
+---@param cwd? string Optional cwd override for context resolution
+function M.render(opts, cwd)
+  return Context.get(cwd):render(opts or "")
 end
 
 --- Send a message or prompt to a CLI
@@ -178,7 +180,7 @@ function M.send(opts)
 
   local msg, text = "", opts.text ---@type string?, sidekick.Text[]?
   if not text then
-    msg, text = M.render(opts)
+    msg, text = M.render(opts, opts.cwd)
     if msg == "" or not text then
       Util.warn("Nothing to send.")
       return

--- a/lua/sidekick/cli/ui/prompt.lua
+++ b/lua/sidekick/cli/ui/prompt.lua
@@ -5,15 +5,12 @@ local Context = require("sidekick.cli.context")
 
 local M = {}
 
----@class sidekick.cli.Prompt
----@field cb fun(msg?:string, text?:sidekick.Text[])
-
----@param opts sidekick.cli.Prompt
+---@param opts sidekick.cli.PromptOpts
 function M.select(opts)
   assert(type(opts) == "table", "opts must be a table")
   local prompts = vim.tbl_keys(Config.cli.prompts) ---@type string[]
   table.sort(prompts)
-  local context = Context.get()
+  local context = Context.get(opts.cwd)
 
   ---@param msg string
   local function tpl(msg)


### PR DESCRIPTION
## Summary

Adds a `cwd` option to `sidekick.cli.send()`, `sidekick.cli.prompt()`, and `sidekick.cli.render()` that allows overriding the working directory used when resolving context variables like `{file}` and `{position}`.

## Use Case

When working in nested project directories (e.g., monorepos or related projects in a parent folder), it's useful to send file context relative to the parent directory rather than the current project root. This allows AI tools to understand the broader project structure.

## Changes

- Added optional `cwd` field to `sidekick.cli.Send` and `sidekick.cli.PromptOpts`
- Updated `Context.get()` to accept optional cwd parameter
- Enhanced path normalization in `location.lua` to handle custom cwd correctly
- Backward compatible: defaults to current working directory when not specified

## Example Usage

```lua
-- Send file with parent directory as context root
require("sidekick.cli").send({
  msg = "{file}",
  cwd = vim.fn.fnamemodify(vim.fn.getcwd(0), ":h")
})
```