### PR TITLE
feat(cli): add support for Mistral Vibe CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ local defaults = {
         env = { OPENCODE_THEME = "system" },
       },
       qwen = { cmd = { "qwen" } },
+      vibe = { cmd = { "vibe" } },
     },
     --- Add custom context. See `lua/sidekick/context/init.lua`
     ---@type table<string, sidekick.context.Fn>
@@ -421,7 +422,6 @@ modify text in normal mode, or after applying an edit.
 <table><tr><th>Cmd</th><th>Lua</th></tr>
 <tr><td><code>:Sidekick nes apply</code> Apply active text edits</td><td>
 
-
 ```lua
 ---@return boolean applied
 require("sidekick.nes").apply()
@@ -430,14 +430,12 @@ require("sidekick.nes").apply()
 </td></tr>
 <tr><td><code>:Sidekick nes clear</code> Clear all active edits</td><td>
 
-
 ```lua
 require("sidekick.nes").clear()
 ```
 
 </td></tr>
 <tr><td><code>:Sidekick nes disable</code> </td><td>
-
 
 ```lua
 
@@ -447,7 +445,6 @@ require("sidekick.nes").disable()
 </td></tr>
 <tr><td><code>:Sidekick nes enable</code> </td><td>
 
-
 ```lua
 ---@param enable? boolean
 require("sidekick.nes").enable(enable)
@@ -456,14 +453,12 @@ require("sidekick.nes").enable(enable)
 </td></tr>
 <tr><td> Check if any edits are active in the current buffer</td><td>
 
-
 ```lua
 require("sidekick.nes").have()
 ```
 
 </td></tr>
 <tr><td><code>:Sidekick nes jump</code> Jump to the start of the active edit</td><td>
-
 
 ```lua
 ---@return boolean jumped
@@ -473,7 +468,6 @@ require("sidekick.nes").jump()
 </td></tr>
 <tr><td><code>:Sidekick nes toggle</code> </td><td>
 
-
 ```lua
 
 require("sidekick.nes").toggle()
@@ -481,7 +475,6 @@ require("sidekick.nes").toggle()
 
 </td></tr>
 <tr><td><code>:Sidekick nes update</code> Request new edits from the LSP server (if any)</td><td>
-
 
 ```lua
 require("sidekick.nes").update()
@@ -504,7 +497,6 @@ diagnostics when requested.
 <table><tr><th>Cmd</th><th>Lua</th></tr>
 <tr><td><code>:Sidekick cli close</code> </td><td>
 
-
 ```lua
 ---@param opts? sidekick.cli.Hide
 ---@overload fun(name: string)
@@ -513,7 +505,6 @@ require("sidekick.cli").close(opts)
 
 </td></tr>
 <tr><td><code>:Sidekick cli focus</code> Toggle focus of the terminal window if it is already open</td><td>
-
 
 ```lua
 ---@param opts? sidekick.cli.Show
@@ -524,7 +515,6 @@ require("sidekick.cli").focus(opts)
 </td></tr>
 <tr><td><code>:Sidekick cli hide</code> </td><td>
 
-
 ```lua
 ---@param opts? sidekick.cli.Hide
 ---@overload fun(name: string)
@@ -533,7 +523,6 @@ require("sidekick.cli").hide(opts)
 
 </td></tr>
 <tr><td><code>:Sidekick cli prompt</code> Select a prompt to send</td><td>
-
 
 ```lua
 ---@param opts? sidekick.cli.Prompt|{cb:nil}
@@ -544,7 +533,6 @@ require("sidekick.cli").prompt(opts)
 </td></tr>
 <tr><td> Render a message template or prompt</td><td>
 
-
 ```lua
 ---@param opts? sidekick.cli.Message|string
 require("sidekick.cli").render(opts)
@@ -552,7 +540,6 @@ require("sidekick.cli").render(opts)
 
 </td></tr>
 <tr><td><code>:Sidekick cli select</code> Start or attach to a CLI tool</td><td>
-
 
 ```lua
 ---@param opts? sidekick.cli.Select|{cb:nil}|{focus?:boolean}
@@ -563,7 +550,6 @@ require("sidekick.cli").select(opts)
 </td></tr>
 <tr><td><code>:Sidekick cli send</code> Send a message or prompt to a CLI</td><td>
 
-
 ```lua
 ---@param opts? sidekick.cli.Send
 ---@overload fun(msg:string)
@@ -573,7 +559,6 @@ require("sidekick.cli").send(opts)
 </td></tr>
 <tr><td><code>:Sidekick cli show</code> </td><td>
 
-
 ```lua
 ---@param opts? sidekick.cli.Show
 ---@overload fun(name: string)
@@ -582,7 +567,6 @@ require("sidekick.cli").show(opts)
 
 </td></tr>
 <tr><td><code>:Sidekick cli toggle</code> </td><td>
-
 
 ```lua
 ---@param opts? sidekick.cli.Show

--- a/lua/sidekick/config.lua
+++ b/lua/sidekick/config.lua
@@ -119,6 +119,7 @@ local defaults = {
         env = { OPENCODE_THEME = "system" },
       },
       qwen = { cmd = { "qwen" } },
+      vibe = { cmd = { "vibe" } },
     },
     --- Add custom context. See `lua/sidekick/context/init.lua`
     ---@type table<string, sidekick.context.Fn>

--- a/sk/cli/vibe.lua
+++ b/sk/cli/vibe.lua
@@ -1,0 +1,23 @@
+---@type sidekick.cli.Config
+return {
+  cmd = { "vibe" },
+  is_proc = "\\<vibe\\>",
+  url = "https://github.com/mistralai/mistral-vibe",
+  continue = { "--continue" },
+  format = function(text)
+    local Text = require("sidekick.text")
+
+    -- Quote paths with special characters
+    Text.transform(text, function(str)
+      return str:find("[^%w%._/\\%-()%[%]{}]") and ('"' .. str .. '"') or str
+    end, "SidekickLocFile")
+
+    local ret = Text.to_string(text)
+
+    -- Strip space between path and line/char references
+    ret = ret:gsub('(@"[^"]+") (:L[%d:LC%-]+)', "%1%2") -- quoted paths
+    ret = ret:gsub("(@[^@%s]+) (:L[%d:LC%-]+)", "%1%2") -- unquoted paths
+
+    return ret
+  end,
+}

--- a/tests/cli_vibe_spec.lua
+++ b/tests/cli_vibe_spec.lua
@@ -1,0 +1,176 @@
+---@module 'luassert'
+
+local vibe = require("sk.cli.vibe")
+
+describe("vibe cli config", function()
+  describe("static properties", function()
+    it("has correct cmd", function()
+      assert.are.same({ "vibe" }, vibe.cmd)
+    end)
+
+    it("has correct is_proc pattern", function()
+      assert.are.equal("\\<vibe\\>", vibe.is_proc)
+    end)
+
+    it("has correct url", function()
+      assert.are.equal("https://github.com/mistralai/mistral-vibe", vibe.url)
+    end)
+
+    it("has correct continue option", function()
+      assert.are.same({ "--continue" }, vibe.continue)
+    end)
+  end)
+
+  describe("format function", function()
+    ---@param chunks {[1]: string, [2]?: string}[][]
+    ---@return sidekick.Text[]
+    local function make_text(chunks)
+      return chunks
+    end
+
+    describe("quoting paths with special characters", function()
+      it("quotes paths containing spaces", function()
+        local text = make_text({
+          { { "path with spaces/file.lua", "SidekickLocFile" } },
+        })
+        local result = vibe.format(text)
+        assert.are.equal('"path with spaces/file.lua"', result)
+      end)
+
+      it("quotes paths containing colons", function()
+        local text = make_text({
+          { { "path:with:colons/file.lua", "SidekickLocFile" } },
+        })
+        local result = vibe.format(text)
+        assert.are.equal('"path:with:colons/file.lua"', result)
+      end)
+
+      it("quotes paths containing special chars like @", function()
+        local text = make_text({
+          { { "@special/file.lua", "SidekickLocFile" } },
+        })
+        local result = vibe.format(text)
+        assert.are.equal('"@special/file.lua"', result)
+      end)
+
+      it("does not quote simple paths", function()
+        local text = make_text({
+          { { "simple/path/file.lua", "SidekickLocFile" } },
+        })
+        local result = vibe.format(text)
+        assert.are.equal("simple/path/file.lua", result)
+      end)
+
+      it("does not quote paths with allowed chars (alphanumeric, dot, slash, backslash, hyphen, parens, brackets, braces)", function()
+        local text = make_text({
+          { { "path/to/file-name_v1.0.lua", "SidekickLocFile" } },
+        })
+        local result = vibe.format(text)
+        assert.are.equal("path/to/file-name_v1.0.lua", result)
+      end)
+
+      it("does not quote paths with parentheses", function()
+        local text = make_text({
+          { { "path/(file).lua", "SidekickLocFile" } },
+        })
+        local result = vibe.format(text)
+        assert.are.equal("path/(file).lua", result)
+      end)
+
+      it("does not quote paths with brackets", function()
+        local text = make_text({
+          { { "path/[file].lua", "SidekickLocFile" } },
+        })
+        local result = vibe.format(text)
+        assert.are.equal("path/[file].lua", result)
+      end)
+
+      it("does not quote paths with braces", function()
+        local text = make_text({
+          { { "path/{file}.lua", "SidekickLocFile" } },
+        })
+        local result = vibe.format(text)
+        assert.are.equal("path/{file}.lua", result)
+      end)
+
+      it("only transforms chunks with SidekickLocFile highlight", function()
+        local text = make_text({
+          { { "path with spaces", "OtherHighlight" } },
+        })
+        local result = vibe.format(text)
+        assert.are.equal("path with spaces", result)
+      end)
+    end)
+
+    describe("stripping space between path and line references", function()
+      it("strips space for quoted paths with line reference", function()
+        local text = make_text({
+          { { '@"some/path.lua"', nil }, { " ", nil }, { ":L10", nil } },
+        })
+        local result = vibe.format(text)
+        assert.are.equal('@"some/path.lua":L10', result)
+      end)
+
+      it("strips space for quoted paths with line range", function()
+        local text = make_text({
+          { { '@"some/path.lua"', nil }, { " ", nil }, { ":L10-15", nil } },
+        })
+        local result = vibe.format(text)
+        assert.are.equal('@"some/path.lua":L10-15', result)
+      end)
+
+      it("strips space for quoted paths with line and column", function()
+        local text = make_text({
+          { { '@"some/path.lua"', nil }, { " ", nil }, { ":L10:C5", nil } },
+        })
+        local result = vibe.format(text)
+        assert.are.equal('@"some/path.lua":L10:C5', result)
+      end)
+
+      it("strips space for unquoted paths with line reference", function()
+        local text = make_text({
+          { { "@some/path.lua", nil }, { " ", nil }, { ":L10", nil } },
+        })
+        local result = vibe.format(text)
+        assert.are.equal("@some/path.lua:L10", result)
+      end)
+
+      it("strips space for unquoted paths with line range", function()
+        local text = make_text({
+          { { "@some/path.lua", nil }, { " ", nil }, { ":L10-20", nil } },
+        })
+        local result = vibe.format(text)
+        assert.are.equal("@some/path.lua:L10-20", result)
+      end)
+
+      it("strips space for unquoted paths with line and column range", function()
+        local text = make_text({
+          { { "@some/path.lua", nil }, { " ", nil }, { ":L10:LC5-10", nil } },
+        })
+        local result = vibe.format(text)
+        assert.are.equal("@some/path.lua:L10:LC5-10", result)
+      end)
+
+      it("handles multiple paths on separate lines", function()
+        local text = make_text({
+          { { "@first.lua", nil }, { " ", nil }, { ":L1", nil } },
+          { { "@second.lua", nil }, { " ", nil }, { ":L2", nil } },
+        })
+        local result = vibe.format(text)
+        assert.are.equal("@first.lua:L1\n@second.lua:L2", result)
+      end)
+    end)
+
+    describe("combined quoting and line reference handling", function()
+      it("quotes special path and strips space before line reference", function()
+        local text = make_text({
+          { { "path with spaces/file.lua", "SidekickLocFile" }, { " ", nil }, { ":L10", nil } },
+        })
+        local result = vibe.format(text)
+        -- After quoting, becomes @"path with spaces/file.lua" :L10
+        -- But the @ is added externally, so we just check quoting happened
+        assert.are.equal('"path with spaces/file.lua" :L10', result)
+      end)
+    end)
+  end)
+end)


### PR DESCRIPTION
Add configuration and tests for the vibe CLI tool from mistralai/mistral-vibe.

## Description

This PR adds support for the [Mistral Vibe ](https://github.com/mistralai/mistral-vibe)CLI tool.
- Adds text transformation to correctly handle paths and line/character selections in a format that Vibe understands
- Adds tests for the CLI config and text transformation
- Updates the README

## Related Issue(s)

N/A

## Screenshots

Selecting the tool:
<img width="1178" height="567" alt="Capture d’écran 2026-01-27 à 06 27 53" src="https://github.com/user-attachments/assets/b86dfce5-ae5e-4612-99a2-8f238aded4c7" />

Sending a visual selection:
<img width="1661" height="1049" alt="Capture d’écran 2026-01-27 à 06 27 06" src="https://github.com/user-attachments/assets/e59f916c-494e-4cac-865b-ab22aa5f1b76" />
