### PR TITLE
fix(codex): replace deprecated web_search_request feature with --search

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ local defaults = {
       aider = { cmd = { "aider" } },
       amazon_q = { cmd = { "q" } },
       claude = { cmd = { "claude" } },
-      codex = { cmd = { "codex", "--enable", "web_search_request" } },
+      codex = { cmd = { "codex", "--search" } },
       copilot = { cmd = { "copilot", "--banner" } },
       crush = {
         cmd = { "crush" },

--- a/doc/sidekick.nvim.txt
+++ b/doc/sidekick.nvim.txt
@@ -339,7 +339,7 @@ Default settings ~
           aider = { cmd = { "aider" } },
           amazon_q = { cmd = { "q" } },
           claude = { cmd = { "claude" } },
-          codex = { cmd = { "codex", "--enable", "web_search_request" } },
+          codex = { cmd = { "codex", "--search" } },
           copilot = { cmd = { "copilot", "--banner" } },
           crush = {
             cmd = { "crush" },

--- a/lua/sidekick/config.lua
+++ b/lua/sidekick/config.lua
@@ -103,7 +103,7 @@ local defaults = {
       aider = { cmd = { "aider" } },
       amazon_q = { cmd = { "q" } },
       claude = { cmd = { "claude" } },
-      codex = { cmd = { "codex", "--enable", "web_search_request" } },
+      codex = { cmd = { "codex", "--search" } },
       copilot = { cmd = { "copilot", "--banner" } },
       crush = {
         cmd = { "crush" },

--- a/sk/cli/codex.lua
+++ b/sk/cli/codex.lua
@@ -1,6 +1,6 @@
 ---@type sidekick.cli.Config
 return {
-  cmd = { "codex", "--enable", "web_search_request" },
+  cmd = { "codex", "--search" },
   is_proc = "\\<codex\\>",
   url = "https://github.com/openai/codex",
   resume = { "resume" },


### PR DESCRIPTION
The `web_search_request` config has been deprecated

## Description

- The Config Reference explicitly marks features.web_search_request as a deprecated legacy toggle and says it maps to `web_search = "live"` when unset. (see https://developers.openai.com/codex/config-reference/)
- Config basics lists the new web_search modes (`cached`, `live`, `disabled`) and calls out legacy/deprecated web-search feature toggles, including `web_search_request`. (see https://developers.openai.com/codex/config-basic)
- The CLI reference documents `--search` as enabling live web search (equivalent to `web_search = "live"`). (see https://developers.openai.com/codex/cli/reference/)
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

N/A <!-- Add screenshots of the changes if applicable. -->
