### PR TITLE
fix(nes): correct inline diff artifact when appending to end of line

### DIFF
--- a/lua/sidekick/nes/diff.lua
+++ b/lua/sidekick/nes/diff.lua
@@ -60,6 +60,12 @@ end
 function M._diff(a, b, opts)
   local txt_a = table.concat(a, "\n")
   local txt_b = table.concat(b, "\n")
+  if txt_a ~= "" then
+    txt_a = txt_a .. "\n"
+  end
+  if txt_b ~= "" then
+    txt_b = txt_b .. "\n"
+  end
   ---@diagnostic disable-next-line: deprecated
   return (vim.text.diff or vim.diff)(txt_a, txt_b, opts) --[[@as (integer[][])]]
 end

--- a/tests/diff_spec.lua
+++ b/tests/diff_spec.lua
@@ -222,7 +222,7 @@ describe("diff", function()
       end,
     },
     {
-      name = "insertion after last column keeps inline change",
+      name = "insertion after last column produces inline add",
       inline = "words",
       edit = {
         from = { 0, #"local foo = 1" },
@@ -232,25 +232,18 @@ describe("diff", function()
       check = function(diff)
         local hunk = diff.hunks[1]
         assert.are.same(true, hunk.inline)
-        assert.are.same("change", hunk.kind)
+        assert.are.same("add", hunk.kind)
         assert.are.same({ 0, 12 }, hunk.pos)
-        assert.are.same(2, #hunk.extmarks)
-        assert.are.same({
-          row = 0,
-          col = 12,
-          end_col = 13,
-          hl_group = "SidekickDiffDelete",
-        }, hunk.extmarks[1])
+        assert.are.same(1, #hunk.extmarks)
         assert.are.same({
           row = 0,
           col = 13,
           virt_text = {
-            { "1", "SidekickDiffAdd" },
             { " ", "SidekickDiffAdd" },
             { "bar", "SidekickDiffAdd" },
           },
           virt_text_pos = "inline",
-        }, hunk.extmarks[2])
+        }, hunk.extmarks[1])
       end,
     },
     {


### PR DESCRIPTION
## Description

When using inline diff mode (`chars` or `words`), appending characters to the end of a line produces a spurious delete-then-re-add of the last existing token before showing the actual insertion. For example, adding a comma after `hello` renders as: delete `o`, add `o`, add `,` — instead of simply showing the `,` insertion.

### Root cause

`_diff` joins token arrays with `\n` via `table.concat(a, "\n")`, producing strings with no trailing newline. When a token is appended, the previously-last token changes from `token<EOF>` to `token\n`, causing `vim.diff` to treat it as a different line. This is the classic "No newline at end of file" diff artifact.

### Fix

Append a trailing `\n` to non-empty diff inputs so all tokens are uniformly newline-terminated. Empty inputs (from edits targeting lines beyond the buffer) are left as `""` to preserve correct insert-vs-change semantics.

The existing test "insertion after last column keeps inline change" was asserting the buggy behavior (a `change` hunk with 2 extmarks). It now correctly expects an `add` hunk with a single extmark.

## Related Issue(s)

Fixes #251

## Screenshots

N/A (inline virtual text rendering change; no new UI elements)