### PR TITLE
fix(cli): check win_valid in ready-check timer to prevent error on toggle

### DIFF
--- a/lua/sidekick/cli/terminal.lua
+++ b/lua/sidekick/cli/terminal.lua
@@ -240,7 +240,7 @@ function M:start()
     READY_CHECK_INTERVAL,
     vim.schedule_wrap(function()
       local elapsed = (vim.uv.hrtime() - ready_start) / 1e6 -- ms
-      if not self:buf_valid() then
+      if not self:buf_valid() or not self:win_valid() then
         return
       end
       if elapsed > READY_MAX_WAIT then


### PR DESCRIPTION
## Summary

- Add `win_valid()` check alongside existing `buf_valid()` check in the ready-check timer callback to prevent `Invalid 'window'` error when toggling the CLI terminal closed while it's still loading

Fixes #252