### PR TITLE
feat(cli): add Cortex Code CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,6 +728,7 @@ Sidekick preconfigures popular AI CLIs. Run `:checkhealth sidekick` to see which
 | [`claude`](https://github.com/anthropics/claude-code)       | Claude Code CLI      | `npm install -g @anthropic-ai/claude-code`                                                                             |
 | [`codex`](https://github.com/openai/codex)                  | OpenAI Codex CLI     | See [OpenAI docs](https://github.com/openai/codex)                                                                     |
 | [`copilot`](https://github.com/github/copilot-cli)          | GitHub Copilot CLI   | `npm install -g @githubnext/github-copilot-cli`                                                                        |
+| [`cortex`](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code-cli) | Snowflake Cortex Code | See [Snowflake docs](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code-cli) |
 | [`crush`](https://github.com/charmbracelet/crush)           | Charm's AI assistant | See [installation](https://github.com/charmbracelet/crush)                                                             |
 | [`cursor`](https://cursor.com/cli)                          | Cursor CLI agent     | See [Cursor docs](https://cursor.com/cli)                                                                              |
 | [`gemini`](https://github.com/google-gemini/gemini-cli)     | Google Gemini CLI    | See [repo](https://github.com/google-gemini/gemini-cli)                                                                |
@@ -737,6 +738,20 @@ Sidekick preconfigures popular AI CLIs. Run `:checkhealth sidekick` to see which
 
 > [!TIP]
 > After installing tools, restart Neovim or run `:Sidekick cli select` to see them available.
+
+> [!TIP]
+> **Cortex Code** supports specifying a Snowflake connection with the `-c` option.
+> Configure it in your `setup()`:
+>
+> ```lua
+> require("sidekick").setup({
+>   cli = {
+>     tools = {
+>       cortex = { cmd = { "cortex", "-c", "my_connection" } },
+>     },
+>   },
+> })
+> ```
 
 ## 🚀 Commands
 

--- a/lua/sidekick/config.lua
+++ b/lua/sidekick/config.lua
@@ -105,6 +105,7 @@ local defaults = {
       claude = { cmd = { "claude" } },
       codex = { cmd = { "codex", "--enable", "web_search_request" } },
       copilot = { cmd = { "copilot", "--banner" } },
+      cortex = { cmd = { "cortex" } },
       crush = {
         cmd = { "crush" },
         -- crush uses <a-p> for its own functionality, so we override the default

--- a/sk/cli/cortex.lua
+++ b/sk/cli/cortex.lua
@@ -1,0 +1,19 @@
+---@type sidekick.cli.Config
+return {
+  cmd = { "cortex" },
+  is_proc = "\\<cortex\\>",
+  url = "https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code-cli",
+  resume = { "resume" },
+  continue = { "--continue" },
+  format = function(text)
+    local Text = require("sidekick.text")
+
+    Text.transform(text, function(str)
+      return str:find("[^%w/_%.%-]") and ('"' .. str .. '"') or str
+    end, "SidekickLocFile")
+
+    local ret = Text.to_string(text)
+    ret = ret:gsub("@([^@]-) :L(%d+)%-L(%d+)", "@%1#L%2-%3")
+    return ret
+  end,
+}


### PR DESCRIPTION
## Description

Add [Cortex Code CLI](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code-cli) (Snowflake's AI coding assistant) as a new CLI tool integration.

- Add `sk/cli/cortex.lua` with tool-specific config (`is_proc`, `format`, `resume`/`continue`)
- Register `cortex` in default tools table in `config.lua`
- Add entry to Default CLI tools table in README

## Related Issue(s)

N/A (new feature request)

## Screenshots

N/A