### PR TITLE
fix(tmux): forward nav keys directly to mux pane on Windows psmux

### DIFF
--- a/lua/sidekick/cli/actions.lua
+++ b/lua/sidekick/cli/actions.lua
@@ -47,6 +47,16 @@ local function nav(dir)
   return function(terminal)
     local at_edge = vim.fn.winnr() == vim.fn.winnr(dir)
     if at_edge or terminal:is_float() then
+      -- When running under a mux backend (e.g., tmux via psmux on Windows),
+      -- returning the key as an expr string passes through Neovim's terminal
+      -- emulation, which can mangle control characters (e.g., C-j becomes CR).
+      -- Send the key directly to the mux pane instead.
+      if terminal.parent and terminal.parent.send_key then
+        vim.schedule(function()
+          terminal.parent:send_key(("C-%s"):format(dir))
+        end)
+        return
+      end
       return ("<c-%s>"):format(dir)
     end
     vim.schedule(function()

--- a/lua/sidekick/cli/session/tmux.lua
+++ b/lua/sidekick/cli/session/tmux.lua
@@ -186,6 +186,14 @@ function M:submit()
   Util.exec({ "tmux", "send-keys", "-t", self.tmux_pane_id, "Enter" })
 end
 
+---Send a raw key to a tmux pane
+---@param key string tmux key name (e.g., "C-j", "Enter", "Escape")
+function M:send_key(key)
+  if self.mux_session then
+    Util.exec({ "tmux", "send-keys", "-t", self.mux_session, key })
+  end
+end
+
 function M:dump()
   local pane_id = self:pane_id()
   if not pane_id then


### PR DESCRIPTION
## Summary

On Windows with psmux, control keys like `C-j` passed through Neovim's terminal emulation get mangled — `C-j` (newline) becomes `CR` (submit). This PR fixes the issue by routing nav key passthrough directly through `tmux send-keys` when a mux parent is available, bypassing the terminal translation layer entirely.

## Changes

- **`lua/sidekick/cli/session/tmux.lua`**: Add `send_key()` method that sends raw keys via `tmux send-keys` targeting by session name.
- **`lua/sidekick/cli/actions.lua`**: In the `nav()` passthrough case (at edge or float), detect mux parent with `send_key` support and route the key directly to the mux pane instead of returning it as an `expr` string.

## Testing

Manually tested on Windows with psmux: `<C-j>` now correctly inserts a newline in CLI tool prompts instead of submitting.