### PR TITLE
fix(nes): accept callbacks without request ids

### DIFF
--- a/lua/sidekick/nes/init.lua
+++ b/lua/sidekick/nes/init.lua
@@ -205,7 +205,7 @@ function M._handler(err, res, ctx)
     return
   end
 
-  if M._requests[ctx.client_id] ~= ctx.request_id then
+  if ctx.request_id ~= nil and M._requests[ctx.client_id] ~= ctx.request_id then
     return -- stale response from a cancelled request
   end
   M._requests[ctx.client_id] = nil


### PR DESCRIPTION
Noticed NES has stopped working for me recently, can't be sure how long tbh. Full disclosure I just had gpt-5.4 debug this for me

It seems the issue is that the neovim callbacks are not including the request_id any more, so all NES suggestions are getting dropped by the stale filter, so I added a check for nil to skip the filter logic. At least it's definitely fixed it on my end.