### PR TITLE
feat(cli): add mux_keys for raw escape sequence passthrough

### DIFF
--- a/lua/sidekick/cli/terminal.lua
+++ b/lua/sidekick/cli/terminal.lua
@@ -154,6 +154,7 @@ function M:start()
   vim.b[self.buf].sidekick_cli = self.tool
 
   self:keys()
+  self:mux_keys()
   self:open_win()
 
   -- track if we are in normal mode or terminal mode
@@ -318,6 +319,37 @@ function M:start()
   end
 end
 
+--- Set up keymaps that bypass Neovim's terminal input processing
+--- and send raw escape sequences directly to the PTY.
+--- This is needed when a multiplexer (tmux/zellij) runs inside a
+--- Neovim terminal buffer, because Neovim's terminal layer cannot
+--- faithfully forward CSI-u / modifyOtherKeys sequences.
+---@param buf? integer
+function M:mux_keys(buf)
+  buf = buf or self.buf
+  -- Only set up mux keys when the terminal wraps a multiplexer session
+  if not self.mux_backend or self.mux_backend == "terminal" then
+    return
+  end
+  local mux_keys = Config.cli.mux.keys
+  if not mux_keys or vim.tbl_isempty(mux_keys) then
+    return
+  end
+  for lhs, raw_seq in pairs(mux_keys) do
+    if type(lhs) == "string" and type(raw_seq) == "string" then
+      vim.keymap.set("t", lhs, function()
+        if self:is_running() then
+          vim.api.nvim_chan_send(self.job, raw_seq)
+        end
+      end, {
+        buffer = buf,
+        silent = true,
+        desc = ("Sidekick mux: send %s to %s"):format(lhs, self.mux_backend),
+      })
+    end
+  end
+end
+
 function M:fix_cursorline()
   if not self:win_valid() then
     return
@@ -333,8 +365,7 @@ function M:on_ready()
       vim.schedule(function()
         if self:is_running() then
           -- Use nvim_put to send input to the terminal
-          -- instead of nvim_chan_send to better simulate user input
-          -- vim.api.nvim_chan_send(self.job, next)
+          -- to better simulate user input
           vim.api.nvim_buf_call(self.buf, function()
             vim.api.nvim_put(vim.split(next, "\n", { plain = true }), "c", false, true)
           end)

--- a/lua/sidekick/config.lua
+++ b/lua/sidekick/config.lua
@@ -94,6 +94,20 @@ local defaults = {
         vertical = true, -- vertical or horizontal split
         size = 0.5, -- size of the split (0-1 for percentage)
       },
+      --- Maps Neovim key notation to raw escape sequences for CSI-u passthrough.
+      --- When enabled, these terminal-mode keymaps bypass Neovim's input
+      --- processing and write raw bytes directly to the PTY via `nvim_chan_send`.
+      --- This is needed because Neovim's terminal layer cannot faithfully
+      --- forward CSI-u / modifyOtherKeys sequences to a multiplexer running
+      --- inside the terminal buffer.
+      --- Example:
+      --- ```lua
+      --- keys = {
+      ---   ["<S-CR>"] = "\x1b[13;2u",
+      ---   ["<A-CR>"] = "\x1b[13;3u",
+      --- }
+      --- ```
+      keys = {}, ---@type table<string, string>
     },
     --- Actual cli tool config is loaded from the runtime path `sk/cli/{tool}.lua` and merged with the config below.
     --- For default configs, see https://github.com/folke/sidekick.nvim/tree/main/sk/cli


### PR DESCRIPTION
When a multiplexer (tmux/zellij) runs inside a Neovim terminal buffer, Neovim terminal layer cannot faithfully forward CSI-u / modifyOtherKeys sequences. Add a mux_keys config field that maps Neovim key notation to raw escape sequences sent directly to the PTY via nvim_chan_send.

Also switch on_ready input forwarding to use nvim_chan_send for mux backends, since nvim_put mangles CSI-u sequences.

Wire up <S-CR> and <A-CR> for the pi CLI tool.


## Related Issue(s)

Fixes #289

