### PR TITLE
fix(tmux): deduplicate panes to prevent "duplicate session id" crash

### DIFF
--- a/lua/sidekick/cli/session/tmux.lua
+++ b/lua/sidekick/cli/session/tmux.lua
@@ -89,9 +89,11 @@ function M.panes(opts)
   local cmd = opts.cmd or { "tmux", "list-panes", "-a", "-F", PANE_FORMAT }
   local lines = Util.exec(cmd, { notify = opts.notify == true })
   local panes = {} ---@type sidekick.tmux.Pane[]
+  local seen = {} ---@type table<string,boolean>
   for _, line in ipairs(lines or {}) do
     local session_id, id, pid, session_name, cwd = line:match("^(%$%d+):(%%%d+):(%d+):(.-):(.*)$")
-    if id and pid and session_name and cwd then
+    if id and pid and session_name and cwd and not seen[id] then
+      seen[id] = true
       pid = assert(tonumber(pid), "invalid tmux pane_pid: " .. pid) --[[@as number]]
       ---@class sidekick.tmux.Pane
       panes[#panes + 1] = {


### PR DESCRIPTION
## Description

Fixes a crash when a tmux window exists in multiple sessions
(e.g. via `link-window` or session groups).

`tmux list-panes -a` returns one entry per session-pane combination,
so a linked pane appears multiple times with the same `pane_pid`.
Since `skid` is derived from `pane_pid`, this produces duplicate IDs
that fail the assert in `session/init.lua:142`.

The fix deduplicates panes by their tmux `pane_id` (e.g. `%5`) in
`M.panes()`. This ID is globally unique per physical pane. Linked
windows share it, so the first occurrence wins. No behavior change
when windows are not linked.

## Related Issue(s)

- Fixes #296

## Screenshots

Crash fix, no UI change.