### PR TITLE
feat(tmux): focus tmux pane after sending text

### DIFF
--- a/lua/sidekick/cli/session/tmux.lua
+++ b/lua/sidekick/cli/session/tmux.lua
@@ -186,6 +186,14 @@ function M:submit()
   Util.exec({ "tmux", "send-keys", "-t", self.tmux_pane_id, "Enter" })
 end
 
+---Focus the tmux pane (select it as the active pane)
+function M:focus()
+  local pane_id = self:pane_id()
+  if pane_id then
+    Util.exec({ "tmux", "select-pane", "-t", pane_id })
+  end
+end
+
 function M:dump()
   local pane_id = self:pane_id()
   if not pane_id then

--- a/lua/sidekick/cli/state.lua
+++ b/lua/sidekick/cli/state.lua
@@ -194,6 +194,8 @@ function M.attach(state, opts)
         terminal:focus()
       end
     end
+  elseif state.session and state.session.focus and opts.focus ~= false then
+    state.session:focus()
   elseif attached then
     Util.info("Attached to `" .. state.tool.name .. "`")
   end


### PR DESCRIPTION
When using tmux mux mode with create = "split" or "window", sending text to the tool pane now switches focus to it via `tmux select-pane`.

Adds M:focus() to the tmux session backend and calls it from State.attach() for external sessions that implement it.

## Description

When using sidekick with a tmux mux backend (`mux.create = "split"` or `"window"`), sending
text to the tool pane does not switch focus to it. The pane receives the input correctly but
stays in the background — the user has to manually click or key-switch to it.

### Root cause

`State.attach()` in `state.lua` already handles focus for Neovim terminal windows: it calls
`terminal:focus()` when `opts.focus ~= false`. However, when the tool runs in an external tmux
pane (no Neovim terminal), `state.terminal` is `nil` and this code path is never reached. The
tmux session backend also had no `focus()` method at all — `send()` pastes text into the pane
via `tmux paste-buffer` but never calls `tmux select-pane`.

### Fix

Two changes:

1. **`lua/sidekick/cli/session/tmux.lua`** — adds a `focus()` method that runs
   `tmux select-pane -t <pane_id>` to bring the pane to the foreground.

2. **`lua/sidekick/cli/state.lua`** — adds an `elseif` branch in `M.attach()` so that when
   there is no terminal window but the session backend implements `focus()`, it is called.
   The `state.session.focus` guard makes this safe for backends that don't implement it
   (e.g. zellij).
