### PR TITLE
fix(cli): route focus() to session for external tmux sessions

### DIFF
--- a/lua/sidekick/cli/init.lua
+++ b/lua/sidekick/cli/init.lua
@@ -121,6 +121,10 @@ end
 function M.focus(opts)
   opts = filter_opts(opts)
   State.with(function(state)
+    if state.external and state.session and state.session.focus then
+      state.session:focus()
+      return
+    end
     if not state.terminal then
       return
     end


### PR DESCRIPTION
### Description

PR #198 made external tmux panes receive focus when attaching via `select`/`show`/`send`, but the dedicated focus keymap (`require("sidekick.cli").focus()`, commonly bound to `<C-.>`) still didn't work for external tmux sessions.

This change adds an external-session branch at the top of the `M.focus` callback that calls `session:focus()` directly, so pressing the focus keymap on an attached external tmux session runs `tmux select-pane` on the sidekick pane as expected.