### PR TITLE
feat(tmux): optionally wrap pane tool command with `direnv exec`

### DIFF
--- a/lua/sidekick/cli/session/tmux.lua
+++ b/lua/sidekick/cli/session/tmux.lua
@@ -79,6 +79,9 @@ function M:add_cmd(ret)
       vim.list_extend(ret, { "-e", ("%s=%s"):format(key, tostring(value)) })
     end
   end
+  if Config.cli.mux.direnv and vim.fn.executable("direnv") == 1 then
+    vim.list_extend(ret, { "direnv", "exec", self.cwd })
+  end
   vim.list_extend(ret, self.tool.cmd)
 end
 

--- a/lua/sidekick/config.lua
+++ b/lua/sidekick/config.lua
@@ -94,6 +94,10 @@ local defaults = {
         vertical = true, -- vertical or horizontal split
         size = 0.5, -- size of the split (0-1 for percentage)
       },
+      -- when true and `direnv` is on PATH, tool commands spawned in external
+      -- tmux panes are wrapped with `direnv exec <cwd>` so per-project
+      -- .envrc files are applied.
+      direnv = false,
     },
     --- Actual cli tool config is loaded from the runtime path `sk/cli/{tool}.lua` and merged with the config below.
     --- For default configs, see https://github.com/folke/sidekick.nvim/tree/main/sk/cli


### PR DESCRIPTION
### Description

When sidekick spawns an external tmux pane, the tool command runs under tmux's server environment and does not pick up per-project env from direnv. This adds a `cli.mux.direnv` option (default `false`) that, when enabled and `direnv` is on PATH, spawns the tool via `direnv exec <cwd> <tool…>` so the `.envrc` is applied without any shell integration. Disabled by default, so behavior is unchanged for users who don't opt in.