### PR TITLE
fix(cli): enable file watcher when attaching to external sessions

### DIFF
--- a/lua/sidekick/cli/session/init.lua
+++ b/lua/sidekick/cli/session/init.lua
@@ -191,6 +191,9 @@ function M.attach(session)
     session:start()
   end
   M._attached[session.id] = session
+  if Config.cli.watch then
+    require("sidekick.cli.watch").enable()
+  end
   Util.emit("SidekickCliAttach", { id = session.id })
   return session
 end


### PR DESCRIPTION
### Description

`watch.enable()` was only called from `terminal.lua` when a Neovim terminal job started, so external tmux panes (`mux.create = "split"` or `"window"`) never triggered `:checktime` on file changes — files edited by the CLI tool wouldn't auto-reload in Neovim. Calling `watch.enable()` in the shared session attach path makes all backends behave the same; the call is idempotent, so the existing terminal invocation is unaffected.