### PR TITLE
fix(cli): apply focus to tmux pane for external sessions

### DIFF
--- a/lua/sidekick/cli/init.lua
+++ b/lua/sidekick/cli/init.lua
@@ -100,14 +100,14 @@ end
 function M.toggle(opts)
   opts = filter_opts(opts)
   State.with(function(state, attached)
-    if not state.terminal then
-      return
-    end
-    if not attached then
+    if state.terminal and not attached then
       state.terminal:toggle()
     end
-    if state.terminal:is_open() and opts.focus ~= false then
-      state.terminal:focus()
+    if opts.focus == false then
+      return
+    end
+    if state.external or (state.terminal and state.terminal:is_open()) then
+      state.session:focus()
     end
   end, {
     attach = true,
@@ -121,13 +121,10 @@ end
 function M.focus(opts)
   opts = filter_opts(opts)
   State.with(function(state)
-    if not state.terminal then
-      return
-    end
-    if state.terminal:is_focused() then
-      state.terminal:blur()
+    if state.session:is_focused() then
+      state.session:blur()
     else
-      state.terminal:focus()
+      state.session:focus()
     end
   end, {
     attach = true,

--- a/lua/sidekick/cli/session/init.lua
+++ b/lua/sidekick/cli/session/init.lua
@@ -52,6 +52,18 @@ function B:attach() end
 --- Detach from an existing session
 function B:detach() end
 
+--- Focus the session
+function B:focus() end
+
+--- Whether the session currently has user focus
+---@return boolean
+function B:is_focused()
+  return false
+end
+
+--- Move focus away from the session
+function B:blur() end
+
 --- Start a new session
 --- If the backend returns a Cmd, a new terminal session will be spawned
 ---@return sidekick.cli.terminal.Cmd?

--- a/lua/sidekick/cli/session/tmux.lua
+++ b/lua/sidekick/cli/session/tmux.lua
@@ -195,4 +195,47 @@ function M:dump()
   return ret
 end
 
+---Focus the tmux pane
+function M:focus()
+  local pane_id = self:pane_id()
+  if not pane_id then
+    return
+  end
+  -- select-window first so create="window" switches the client to the pane's window;
+  -- no-op for create="split" where the pane is already in the current window.
+  Util.exec({ "tmux", "select-window", "-t", pane_id })
+  Util.exec({ "tmux", "select-pane", "-t", pane_id })
+end
+
+---Whether this tmux pane is the active pane of the calling client
+---@return boolean
+function M:is_focused()
+  local pane_id = self:pane_id()
+  if not pane_id then
+    return false
+  end
+  local lines = Util.exec({
+    "tmux",
+    "display-message",
+    "-p",
+    "-t",
+    pane_id,
+    "#{==:#{client_active_pane},#{pane_id}}",
+  }, { notify = false })
+  return lines ~= nil and lines[1] == "1"
+end
+
+---Send focus back to the editor pane (identified via $TMUX_PANE)
+function M:blur()
+  if not self:is_focused() then
+    return
+  end
+  local editor_pane = vim.env.TMUX_PANE
+  if not editor_pane then
+    return
+  end
+  Util.exec({ "tmux", "select-window", "-t", editor_pane }, { notify = false })
+  Util.exec({ "tmux", "select-pane", "-t", editor_pane }, { notify = false })
+end
+
 return M

--- a/lua/sidekick/cli/state.lua
+++ b/lua/sidekick/cli/state.lua
@@ -187,14 +187,14 @@ function M.attach(state, opts)
 
   state = M.get_state(session) -- update state
   local terminal = state.terminal
-  if terminal then
-    if opts.show then
-      terminal:show()
-      if opts.focus ~= false and terminal:is_running() then
-        terminal:focus()
-      end
-    end
-  elseif attached then
+  if terminal and opts.show then
+    terminal:show()
+  end
+  local visible = state.external or (terminal and terminal:is_running())
+  if opts.show and opts.focus ~= false and visible then
+    session:focus()
+  end
+  if not terminal and attached then
     Util.info("Attached to `" .. state.tool.name .. "`")
   end
   return state, attached


### PR DESCRIPTION
## Description

`cli.toggle({ focus = true })` and `cli.focus()` did not focus the tmux pane when using external mux sessions (`cli.mux.enabled = true` with `create = "split"` / `"window"`).

### Root cause

`sidekick.cli` was built around `state.terminal` (nvim's embedded terminal). When external mux sessions were added, the UI layer (`M.toggle` / `M.focus`) still keyed off `state.terminal`, and `Session` had no `focus()` method — so there was literally no path from the UI to `tmux select-pane`. Terminal focus kept working only because `nvim_set_current_win` is a synchronous API the UI callback could call directly via a captured `opts.focus`, bypassing the missing propagation.

### Changes

- Promote `focus`, `is_focused`, and `blur` to `Session` contract (empty / `false` defaults on the base for backends that don't support them)
- Implement them on the tmux backend:
  - `focus`: `tmux select-window` then `tmux select-pane` — `select-window` first so `create = "window"` switches the client to the pane's window (no-op for `create = "split"`)
  - `is_focused`: `tmux display-message` comparing `#{client_active_pane}` with the pane id
  - `blur`: switch back to the editor pane identified via `$TMUX_PANE` (the env var tmux sets for the pane nvim is running in) — works regardless of tmux history
- Unify the UI layer through `state.session:*`. `Terminal` is already registered as a `Session` backend (`state.terminal === state.session` for terminal-backed sessions), so the same calls work for both paths:
  - terminal-backed session → `Terminal:focus()` / `:is_focused()` / `:blur()` (existing methods)
  - external tmux session → `Tmux:focus()` / `:is_focused()` / `:blur()` (new)
- `M.attach` now fires focus on `opts.show and opts.focus ~= false` for both backends, fixing the silent default-false asymmetry external previously had against terminal
- `M.toggle` callback handles both backends via `state.session:focus()`, keeping the existing `is_open()` gate so toggling terminal visibility off doesn't immediately re-open it
- `M.focus` callback uses `state.session:is_focused()` / `:blur()` / `:focus()` directly — the toggle-focus behavior now applies to external panes too (when invoked from inside the pane, e.g. via a tmux keybinding that calls back into nvim)

### Behavior matrix after the fix

| Call | terminal | external tmux |
|---|---|---|
| `toggle()` | toggle visibility + focus | focus pane |
| `toggle({ focus = true })` | toggle visibility + focus | focus pane |
| `toggle({ focus = false })` | toggle visibility only | no-op |
| `send("x")` | show + focus, then send | focus pane, then send |
| `send("x", { focus = false })` | show, then send | send only |
| `focus()` from editor | focus pane (terminal not currently focused) | focus pane |
| `focus()` from inside the pane | blur (back to previous window) | blur (back to `$TMUX_PANE`) |
| `hide()` | hide window | no-op (filter excludes external) |
| `close()` | close terminal | detach tracking (pane stays) |

## Related Issue(s)

- Fixes #179

## Screenshots

N/A — behavioral fix with no UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)