### PR TITLE
feat(zellij): implement dump() with --ansi flag for scrollback support

### DIFF
--- a/lua/sidekick/cli/session/zellij.lua
+++ b/lua/sidekick/cli/session/zellij.lua
@@ -110,28 +110,17 @@ function M.sessions()
   return ret
 end
 
--- function M:dump()
---   do
---     -- sigh, another broken zellij feature
---     -- dump-screen doesn't include ansi escape sequences
---     -- just the raw text
---     return
---   end
---   local tmp = Config.state("zellij-dump.txt")
---   local ok = Util.exec({ "zellij", "-s", self.mux_session, "action", "dump-screen", "-f", tmp }, {
---     notify = true,
---   })
---   if not ok then
---     return
---   end
---   local f = io.open(tmp, "r")
---   if not f then
---     return
---   end
---   vim.fn.delete(tmp)
---   local content = f:read("*a")
---   f:close()
---   return content
--- end
+function M:dump()
+  if self.mux_session == nil then
+    return
+  end
+  local ok, ret = Util.exec({ "zellij", "-s", self.mux_session, "action", "dump-screen", "-f", "--ansi" }, {
+    notify = true,
+  })
+  if not ok or ret == "" then
+    return
+  end
+  return ret
+end
 
 return M


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Re-enable the dump() method for zellij backend using stdout output instead of a temp file.

Zellij added --ansi support to dump-screen in version [0.44](https://github.com/zellij-org/zellij/releases/tag/v0.44.0), enabling ANSI escape sequences in the output.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->