### PR TITLE
fix(tmux): honor config `win.layout=left` when splitting in tmux

### DIFF
--- a/lua/sidekick/cli/session/tmux.lua
+++ b/lua/sidekick/cli/session/tmux.lua
@@ -44,6 +44,9 @@ function M:start()
   elseif Config.cli.mux.create == "split" then
     local cmd = { "tmux", "split-window", "-dP", "-c", self.cwd, "-F", PANE_FORMAT }
     cmd[#cmd + 1] = Config.cli.mux.split.vertical and "-h" or "-v"
+    if Config.cli.win.layout == "left" then
+      cmd[#cmd + 1] = "-b"
+    end
     local size = Config.cli.mux.split.size
     vim.list_extend(cmd, { "-l", tostring(size <= 1 and ((size * 100) .. "%") or size) })
     self:add_cmd(cmd)


### PR DESCRIPTION
## Description
Splitting in tmux didn't show on the left when with `win.layout=left` setting 
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots
<img width="1740" height="1307" alt="Screenshot 2026-04-25 at 13 33 53" src="https://github.com/user-attachments/assets/03d9c2d4-8e95-4469-9f21-39d7088bcef6" />

<!-- Add screenshots of the changes if applicable. -->

