### PR TITLE
fix(zellij): remove whitespace on zellij layout file for Windows

### DIFF
--- a/lua/sidekick/cli/session/init.lua
+++ b/lua/sidekick/cli/session/init.lua
@@ -104,7 +104,7 @@ end
 function M.sid(opts)
   local tool = assert(opts and opts.tool, "missing tool")
   local cwd = M.cwd(opts)
-  return ("%s %s"):format(tool, vim.fn.sha256(cwd):sub(1, 16 - #tool))
+  return ("%s-%s"):format(tool, vim.fn.sha256(cwd):sub(1, 16 - #tool))
 end
 
 ---@param name string


### PR DESCRIPTION
## Description

Simple fix: On Windows, if session has a space, such as `claude c4e5832c2f`, then when trying to open up a terminal using zellij, `local layout-file` inside zellij.lua becomes a string with a space, specifically `config/zellij-layout-claude c9867a1555.kdl`. Sidekick then seems to call zellij to initiate a terminal doing something like:
```
zellij --layout C:\Users\user\AppData\Local\nvim-data/sidekick/zellij-layout-claude c9867a1555.kdl
```

Which just causes the command to treat the last chunk as an extra argument, leading to the new zellij terminal to error with:
```
error: Found argument 'c9867a1555.kdl' which wasn't expected, or isn't valid in 
this context
```

The simplest fix (the one applied in this PR) is to just ensure session doesn't have whitespace by changing the format from `%s %s` to `%s-%s`

## Screenshots

Issue screenshot:
<img width="1920" height="979" alt="image" src="https://github.com/user-attachments/assets/8233bd21-ff52-47ad-ae97-3602cf0996b6" />


