### PR TITLE
fix(cursor): fix cursor agent command

### DIFF
--- a/sk/cli/cursor.lua
+++ b/sk/cli/cursor.lua
@@ -1,6 +1,6 @@
 ---@type sidekick.cli.Config
 return {
-  cmd = { "cursor-agent" },
+  cmd = { "cursor", "agent" },
   is_proc = "\\<cursor-agent\\>",
   url = "https://cursor.com/cli"
 }


### PR DESCRIPTION
## Description

On macOS, `cursor-agent` triggers Apple's Security & Privacy protection and crashes (screenshot 1).

However, either `cursor agent` or `agent` works fine (screenshot 2).

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

### Screenshot 1

`cursor-agent` Security & Privacy Alert:

<img width="1725" height="1066" alt="2026-06-04_16-01-15" src="https://github.com/user-attachments/assets/ebd531d8-725c-4057-8f1f-c5c839aa1c9f" />

### Screenshot 2

`cursor agent` working as expected:

<img width="1728" height="1066" alt="image" src="https://github.com/user-attachments/assets/f574e71e-7e29-4613-b08e-9e9c97c78251" />
