### PR TITLE
feat(cli): send github issues/prs from snacks picker to the cli

### DIFF
--- a/lua/sidekick/cli/picker/init.lua
+++ b/lua/sidekick/cli/picker/init.lua
@@ -31,6 +31,19 @@ function M.get(picker)
   Util.error("No valid picker found")
 end
 
+---@param item table
+---@return boolean
+local function is_gh_item(item)
+  return item ~= nil and item.type ~= nil and item.repo ~= nil and item.number ~= nil
+end
+
+---@param item table
+---@return string
+local function gh_ref(item)
+  -- GitHub's standard cross-repo autolink format (owner/repo#number).
+  return string.format("%s#%d", item.repo, item.number)
+end
+
 ---@param opts? sidekick.context.loc.Opts|sidekick.cli.Send
 function M._send_cb(opts)
   opts = opts or {}
@@ -39,10 +52,15 @@ function M._send_cb(opts)
     local Loc = require("sidekick.cli.context.location")
     local ret = { { " " } } ---@type sidekick.Text
     for _, item in ipairs(items) do
-      local file = Loc.get(item, { kind = opts.kind or "file" })[1]
-      if file then
-        vim.list_extend(ret, file)
-        ret[#ret + 1] = { " " }
+      if is_gh_item(item) then
+        ret[#ret + 1] = { gh_ref(item) }
+        ret[#ret + 1] = { "\n" }
+      else
+        local file = Loc.get(item, { kind = opts.kind or "file" })[1]
+        if file then
+          vim.list_extend(ret, file)
+          ret[#ret + 1] = { " " }
+        end
       end
     end
     vim.schedule(function()


### PR DESCRIPTION
## Description

Add support for sending a GitHub issue/PR selected in a picker to the CLI as context.

When a picker item is a GitHub issue/PR (detected by the presence of `type`, `repo`, and `number` fields, as exposed by snacks' `gh_issues` / `gh_prs` sources), the send callback now emits the reference in GitHub's standard cross-repo autolink format:

```
owner/repo#number
```

e.g. `folke/sidekick.nvim#123`.

This format is the documented GitHub autolink reference, so the output is compact for the agent and remains clickable when pasted back into GitHub. It intentionally does not distinguish PR from issue, since they share the same number space on GitHub.

Non-GitHub items keep falling back to the existing file/location behavior, so the change is backwards compatible and scoped to the picker send path (`lua/sidekick/cli/picker/init.lua`).

## Related Issue(s)

- Fixes #335

## Screenshots

Not applicable — this is a change to the text sent to the CLI, with no visual/UI changes. Resulting context for a selected GitHub issue looks like:

```
folke/sidekick.nvim#123
```